### PR TITLE
Add template validation script and CI

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -1,0 +1,19 @@
+name: Validate Template
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run template validation
+        run: |
+          docker run --rm \
+            -v "$PWD":/workspace \
+            -w /workspace \
+            devopsfaith/krakend \
+            bash tests/validate_template.sh
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+# Test Scripts
+
+This directory contains helper scripts for validating the flexible
+configuration used in this repository.
+
+Run the template validation with:
+
+```bash
+./validate_template.sh
+```
+
+The script runs `krakend check` with the same environment variables
+used in the examples and exits with the status returned by `krakend`.

--- a/tests/validate_template.sh
+++ b/tests/validate_template.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+FC_ENABLE=1 \
+FC_SETTINGS=config/settings \
+FC_PARTIALS=config/partials \
+FC_TEMPLATES=config/templates \
+FC_OUT=/tmp/krakend.json \
+krakend check -t -d -c krakend.tmpl
+exit $?


### PR DESCRIPTION
## Summary
- add a helper script to check flexible templates
- document running the script
- run validation automatically in GitHub Actions

## Testing
- `./tests/validate_template.sh` *(fails: `krakend` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686680afaaa8832db9a83e4c5f68ed87